### PR TITLE
Stg namespace scoping

### DIFF
--- a/libstage/region.cc
+++ b/libstage/region.cc
@@ -8,29 +8,29 @@
 #include "region.hh"
 using namespace Stg;
 
-std::vector<Stg::Cell*> Region::dead_pool;
+std::vector<Stg::Cell*> Stg::Region::dead_pool;
 
-Region::Region() : 
+Stg::Region::Region() : 
   cells(NULL), 
   count(0),
   superregion(NULL)
 {
 }
 
-Region::~Region()
+Stg::Region::~Region()
 {
   if( cells )
     delete[] cells;
 }
 
-void Region::AddBlock()
+void Stg::Region::AddBlock()
 { 
   ++count; 
   assert(count>0);
   superregion->AddBlock();
 }
 
-void Region::RemoveBlock()
+void Stg::Region::RemoveBlock()
 {
   --count; 
   assert(count>=0); 


### PR DESCRIPTION
I've just added some missing Stg namespace scoping to libstage/region.cc to fix some compile conflicts with X11 Regions.
