### PR TITLE
Fixed compiler warnings when using Clang.

### DIFF
--- a/examples/ctrl/astar/findpath.cpp
+++ b/examples/ctrl/astar/findpath.cpp
@@ -27,16 +27,10 @@ static unsigned int _map_width=0, _map_height=0;
 uint8_t GetMap( unsigned int x, unsigned int y )
 {
   assert(_map);
-  
-  if( x < 0 ||
-		x >= _map_width ||
-		y < 0 ||
-		y >= _map_height
-		)
-	 {
-		return 9;	 
-	 }
-  
+
+  if(x >= _map_width || y >= _map_height)
+		return 9;
+
 	return _map[(y*_map_width)+x];
 }
 

--- a/libstage/ancestor.cc
+++ b/libstage/ancestor.cc
@@ -56,7 +56,7 @@ void Ancestor::RemoveChild( Model* mod )
   EraseAll( mod, children );
 }
 
-Pose Ancestor::GetGlobalPose()
+Pose Ancestor::GetGlobalPose() const
 {
 	Pose pose;
 	memset( &pose, 0, sizeof(pose));

--- a/libstage/stage.hh
+++ b/libstage/stage.hh
@@ -714,8 +714,8 @@ namespace Stg
 	 
     virtual void AddChild( Model* mod );
     virtual void RemoveChild( Model* mod );
-    virtual Pose GetGlobalPose();
-	 
+    virtual Pose GetGlobalPose() const;
+
     const char* Token(){ return token.c_str(); }
 
     const std::string& TokenStr(){ return token; }

--- a/libstageplugin/p_driver.h
+++ b/libstageplugin/p_driver.h
@@ -108,6 +108,8 @@ class InterfaceModel
 
   virtual void Subscribe( void );
   virtual void Unsubscribe( void );
+  virtual void Subscribe( QueuePointer &queue );
+  virtual void Unsubscribe( QueuePointer &queue );
 
  protected:
   Stg::Model* mod;


### PR DESCRIPTION
Stage now compiles without any warnings or errors when using '-Wall' on Clang 2.9.
