### PR TITLE
Add leading zeros to Stage generated screenshot file names.

### DIFF
--- a/libstage/canvas.cc
+++ b/libstage/canvas.cc
@@ -1100,7 +1100,7 @@ void Canvas::Screenshot()
   
   static uint32_t count = 0;		 
   char filename[64];
-  snprintf( filename, 63, "stage-%d.png", count++ );
+  snprintf( filename, 63, "stage-%06d.png", count++ );
   
   FILE *fp = fopen( filename, "wb" );
   if( fp == NULL ) 


### PR DESCRIPTION
Currently stage creates screenshots in this format:

stage-1.png
stage-2.png

This commit changes that to this:

stage-000001.png
stage-000002.png

This way it is easier to perform batch operations on these files using tools like `ffmpeg` or `convert`
