### PR TITLE
Provide the integration_error (odom_error on world file)

### DIFF
--- a/libstage/stage.hh
+++ b/libstage/stage.hh
@@ -2999,6 +2999,9 @@ namespace Stg
     /* set the velocity of a model in the global coordinate system */
     void SetGlobalVelocity( const Velocity& gvel );
 
+    /** Get (a copy of) the model's odometry integration error. */
+    Velocity GetOdomError() const { return integration_error; }
+
     /** Specify a point in space. Arrays of Waypoints can be attached to
 	Models and visualized. */
     class Waypoint


### PR DESCRIPTION
 so it can be used to fill covariances by wrappers, for example on stageros nav_msgs::Odometry
