### PR TITLE
Fix debug build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,7 +54,7 @@ endif( PROJECT_OS_OSX)
 SET (OPTIMIZE "-O2")
 
 SET (CMAKE_CXX_FLAGS_RELEASE " ${FORCE_ARCH} ${OPTIMIZE} -DNDEBUG ${WALL} " CACHE INTERNAL "C Flags for release" FORCE)
-SET (CMAKE_CXX_FLAGS_DEBUG " -ggdb  ${FORCE_ARCH} ${WALL} " CACHE INTERNAL "C Flags for debug" FORCE)
+SET (CMAKE_CXX_FLAGS_DEBUG " -ggdb  ${FORCE_ARCH} ${WALL} -DDEBUG" CACHE INTERNAL "C Flags for debug" FORCE)
 SET (CMAKE_CXX_FLAGS_PROFILE " -ggdb -pg  ${FORCE_ARCH} ${WALL} " CACHE INTERNAL "C Flags for profile" FORCE)
 
 #####################################

--- a/libstage/blockgroup.cc
+++ b/libstage/blockgroup.cc
@@ -293,7 +293,7 @@ void BlockGroup::LoadBlock( Worldfile* wf, int entity )
 
 void BlockGroup::LoadBitmap( const std::string& bitmapfile, Worldfile* wf )
 {
-  PRINT_DEBUG1( "attempting to load bitmap \"%s\n", bitmapfile );
+  PRINT_DEBUG1( "attempting to load bitmap \"%s\n", bitmapfile.c_str() );
 
   std::string full;
 
@@ -311,7 +311,7 @@ void BlockGroup::LoadBitmap( const std::string& bitmapfile, Worldfile* wf )
   fputs( buf, stdout );
   fflush( stdout );
   
-  PRINT_DEBUG1( "attempting to load image %s", full );
+  PRINT_DEBUG1( "attempting to load image %s", full.c_str() );
     
   Color col( 1.0, 0.0, 1.0, 1.0 );
   

--- a/libstage/file_manager.cc
+++ b/libstage/file_manager.cc
@@ -58,7 +58,7 @@ namespace Stg
 
 			ranOnce = true;
 			
-			PRINT_DEBUG1("FileManager - INIT: %d paths in search paths\n", paths.size() );
+			PRINT_DEBUG1("FileManager - INIT: %lu paths in search paths\n", paths.size() );
 		}
 
 		// search the path list

--- a/libstage/model_actuator.cc
+++ b/libstage/model_actuator.cc
@@ -183,7 +183,7 @@ void ModelActuator::Load( void )
 
 void ModelActuator::Update( void  )
 {
-	PRINT_DEBUG1( "[%lu] actuator update", 0 );
+	PRINT_DEBUG1( "[%lu] actuator update", 0L );
 
 	// stop by default
 	double velocity = 0;
@@ -221,7 +221,7 @@ void ModelActuator::Update( void  )
 				{
 					PRINT_DEBUG( "actuator velocity control mode" );
 					PRINT_DEBUG2( "model %s command(%.2f)",
-							this->token,
+							this->token.c_str(),
 							this->goal);
 					if ((pos <= min_position && goal < 0) || (pos >= max_position && goal > 0))
 						velocity = 0;

--- a/libstage/model_blinkenlight.cc
+++ b/libstage/model_blinkenlight.cc
@@ -67,7 +67,7 @@ ModelBlinkenlight::ModelBlinkenlight( World* world,
   on( true )
 {
 	PRINT_DEBUG2( "Constructing ModelBlinkenlight %d (%s)\n", 
-			id, typestr );
+			id, type.c_str() );
 
 	// Set up sensible defaults
 

--- a/libstage/model_blobfinder.cc
+++ b/libstage/model_blobfinder.cc
@@ -94,7 +94,7 @@ ModelBlobfinder::ModelBlobfinder( World* world,
   scan_width( DEFAULT_BLOBFINDERSCANWIDTH )
 {
   PRINT_DEBUG2( "Constructing ModelBlobfinder %d (%s)\n", 
-		id, typestr );	
+		id, type.c_str() );	
   ClearBlocks();
   
   AddVisualizer( &this->vis, true );

--- a/libstage/model_camera.cc
+++ b/libstage/model_camera.cc
@@ -103,7 +103,7 @@ ModelCamera::ModelCamera( World* world,
   _pitch_offset( 0.0 )  
 {
 	PRINT_DEBUG2( "Constructing ModelCamera %d (%s)\n", 
-			id, typestr );
+			id, type.c_str() );
 
 	WorldGui* world_gui = dynamic_cast< WorldGui* >( world );
 	

--- a/libstage/model_position.cc
+++ b/libstage/model_position.cc
@@ -118,7 +118,7 @@ ModelPosition::ModelPosition( World* world,
   posevis()
 {
   PRINT_DEBUG2( "Constructing ModelPosition %d (%s)\n", 
-		id, typestr );
+		id, type.c_str() );
   
   // assert that Update() is reentrant for this derived model
   thread_safe = false;
@@ -292,7 +292,7 @@ void ModelPosition::Load( void )
 
 void ModelPosition::Update( void  )
 { 
-  PRINT_DEBUG1( "[%lu] position update", this->world->sim_time );
+  PRINT_DEBUG1( "[%lu] position update", this->world->SimTimeNow());
 
   // stop by default
   Velocity vel(0,0,0,0);

--- a/libstage/model_ranger.cc
+++ b/libstage/model_ranger.cc
@@ -95,7 +95,7 @@ ModelRanger::ModelRanger( World* world,
     vis( world ) 
 {
   PRINT_DEBUG2( "Constructing ModelRanger %d (%s)\n", 
-		id, type );
+		id, type.c_str() );
   
   // Set up sensible defaults
   

--- a/libstage/world.cc
+++ b/libstage/world.cc
@@ -184,7 +184,7 @@ World::World( const std::string& name,
 
 World::~World( void )
 {
-  PRINT_DEBUG2( "destroying world %d %s", id, Token() );
+  PRINT_DEBUG1( "destroying world %s", Token() );
   if( ground ) delete ground;
   if( wf ) delete wf;
   World::world_set.erase( this );

--- a/libstage/worldgui.cc
+++ b/libstage/worldgui.cc
@@ -255,7 +255,7 @@ void WorldGui::Show()
 
 bool WorldGui::Load( const std::string& filename )
 {
-  PRINT_DEBUG1( "%s.Load()", token );
+  PRINT_DEBUG1( "%s.Load()", token.c_str() );
 	
   // needs to happen before StgWorld load, or we segfault with GL calls on some graphics cards
   Fl::check();
@@ -322,7 +322,7 @@ void WorldGui::UnLoad()
 
 bool WorldGui::Save( const char* filename )
 {
-  PRINT_DEBUG1( "%s.Save()", token );
+  PRINT_DEBUG1( "%s.Save()", token.c_str() );
   
   // worldgui exclusive properties live in the top-level section
   const int world_section = 0; 


### PR DESCRIPTION
PRINT_DEBUG messages aren't enabled in debug build.
Enabling PRINT_DEBUG messages spawn a lot of warn/err, seems like debug msgs didn't get updated along with the changes made to libstage.