### PR TITLE
Don't overwrite the loaded filename when opening includes

### DIFF
--- a/libstage/worldfile.cc
+++ b/libstage/worldfile.cc
@@ -98,8 +98,7 @@ FILE *Worldfile::FileOpen(const std::string &filename, const char *method)
     assert(strlen(fullpath) + 1 < PATH_MAX);
     fp = fopen(fullpath, method);
     if (fp) {
-      this->filename = std::string(fullpath);
-      PRINT_DEBUG1("Loading: %s", filename.c_str());
+      PRINT_DEBUG1("Loading: %s", fullpath);
       free(tmp);
       return fp;
     }


### PR DESCRIPTION
The filename of the worldfile is used to find include files, bitmaps (and maybe other things?). When handling includes that are found through the `STAGEPATH`, the filename of the worldfile is overwritten. Later on when for example loading bitmaps, the `STAGEPATH` is not evaluated anymore, instead only the filename is used. In my case bitmaps are located next to the original world file, not near files somewhere in the `STAGEPATH`.

Another scenario is the save functionality, which will actually attempt to save the world file to the path of the last include instead of the original world file.