### PR TITLE
Add support for speedup/real-time simulation in non-GUI mode

### DIFF
--- a/libstage/stage.hh
+++ b/libstage/stage.hh
@@ -47,6 +47,7 @@
 
 // C++ libs
 #include <algorithm>
+#include <chrono>
 #include <cmath>
 #include <iostream>
 #include <list>
@@ -852,6 +853,11 @@ protected:
   std::list<float *> ray_list; ///< List of rays traced for debug visualization
   usec_t sim_time; ///< the current sim time in this world in microseconds
   std::map<point_int_t, SuperRegion *> superregions;
+  std::chrono::time_point<std::chrono::steady_clock> next_run_time;
+  usec_t real_time_between_runs;
+  /** Stage attempts to run this many times faster than real
+  time. If -1, Stage runs as fast as possible. */
+  double speedup;
 
   uint64_t updates; ///< the number of simulated time steps executed so far
   Worldfile *wf; ///< If set, points to the worldfile used to create this world
@@ -859,6 +865,7 @@ protected:
   void CallUpdateCallbacks(); ///< Call all calbacks in cb_list, removing any that return true;
 
 public:
+  std::chrono::time_point<std::chrono::steady_clock> NextRunTime() { return next_run_time; }
   uint64_t UpdateCount() { return updates; }
   bool paused; ///< if true, the simulation is stopped
 
@@ -1032,6 +1039,7 @@ updates */
 public:
   /** returns true when time to quit, false otherwise */
   static bool UpdateAll();
+  static bool UpdateAll(std::chrono::time_point<std::chrono::steady_clock> &next_run);
 
   /** run all worlds.
  *  If only non-gui worlds were created, UpdateAll() is
@@ -1429,10 +1437,6 @@ private:
   std::vector<Option *> drawOptions;
   FileManager *fileMan; ///< Used to load and save worldfiles
   std::vector<usec_t> interval_log;
-
-  /** Stage attempts to run this many times faster than real
-time. If -1, Stage runs as fast as possible. */
-  double speedup;
 
   bool confirm_on_quit; ///< if true, show save dialog on (GUI) exit (default)
 

--- a/libstage/worldgui.cc
+++ b/libstage/worldgui.cc
@@ -194,11 +194,13 @@ static const char *MoreHelpText =
 
 WorldGui::WorldGui(int width, int height, const char *caption)
     : Fl_Window(width, height, NULL), canvas(new Canvas(this, 0, 30, width, height - 30)),
-      drawOptions(), fileMan(new FileManager()), interval_log(), speedup(1.0), // real time
+      drawOptions(), fileMan(new FileManager()), interval_log(),
       confirm_on_quit(true), mbar(new Fl_Menu_Bar(0, 0, width, 30)), oDlg(NULL), pause_time(false),
       real_time_interval(sim_interval), real_time_now(RealTimeNow()),
       real_time_recorded(real_time_now), timing_interval(20)
 {
+  speedup = 1.0; // default in GUI mode is realtime
+
   Fl::lock(); // start FLTK's thread safe behaviour
 
   Fl::scheme("");
@@ -301,7 +303,6 @@ void WorldGui::LoadWorldGuiPostHook(usec_t load_start_time)
 {
   // worldgui exclusive properties live in the top-level section
   const int world_section = 0;
-  speedup = wf->ReadFloat(world_section, "speedup", speedup);
   paused = wf->ReadInt(world_section, "paused", paused);
   confirm_on_quit = wf->ReadInt(world_section, "confirm_on_quit", confirm_on_quit);
 


### PR DESCRIPTION
This PR adds support for the use of `speedup` when running headless similar to when using the GUI. The default behaviour in headless is still to run as fast as possible. Addresses #89.